### PR TITLE
Feature/1.3.1 info and relationships

### DIFF
--- a/src/components/accessibility-configurator/accessibility-configurator.js
+++ b/src/components/accessibility-configurator/accessibility-configurator.js
@@ -39,7 +39,6 @@ const AccessibilityConfigurator = () => {
       allInternalRule {
         nodes {
           key
-          axeId
           wcagId
           description
           title

--- a/src/components/breadcrumbs/breadcrumbs.jsx
+++ b/src/components/breadcrumbs/breadcrumbs.jsx
@@ -1,7 +1,9 @@
 import React, { useContext } from "react"
 import { Link, graphql, useStaticQuery } from "gatsby"
 
+import CONSTANTS from "../../data/rules/constants"
 import LocationContext from "../location-context"
+import AccessibilityRulesContext from "../accessibility-rules/accessibility-rules-context"
 
 import "./breadcrumbs.css"
 
@@ -13,6 +15,7 @@ import "./breadcrumbs.css"
 
 const Breadcrumbs = () => {
   const { location } = useContext(LocationContext)
+  const { rules } = useContext(AccessibilityRulesContext)
 
   if (!location) {
     return null
@@ -41,9 +44,18 @@ const Breadcrumbs = () => {
   if (!currentSitePage || !currentSitePage.context.breadcrumbs) {
     return null
   }
-
+  const NavElement = rules[CONSTANTS.GROUP_RELATED_LINKS_USING_THE_NAV_ELEMENT]
+    ? "nav"
+    : "div"
   return (
-    <nav className="breadcrumbs" aria-label="Breadcrumbs">
+    <NavElement
+      className="breadcrumbs"
+      aria-label={
+        rules[CONSTANTS.GROUP_RELATED_LINKS_USING_THE_NAV_ELEMENT]
+          ? "Breadcrumbs"
+          : undefined
+      }
+    >
       <ol className="breadcrumbs__list">
         {currentSitePage.context.breadcrumbs.map(breadcrumb => (
           <li className="breadcrumbs__list__item" key={breadcrumb.path}>
@@ -61,7 +73,7 @@ const Breadcrumbs = () => {
           </li>
         ))}
       </ol>
-    </nav>
+    </NavElement>
   )
 }
 

--- a/src/components/breadcrumbs/breadcrumbs.jsx
+++ b/src/components/breadcrumbs/breadcrumbs.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react"
 import { Link, graphql, useStaticQuery } from "gatsby"
 
+import { withoutTrailingSlash } from "../../util/url-util"
 import CONSTANTS from "../../data/rules/constants"
 import LocationContext from "../location-context"
 import AccessibilityRulesContext from "../accessibility-rules/accessibility-rules-context"
@@ -38,7 +39,9 @@ const Breadcrumbs = () => {
   `)
 
   const currentSitePage = data.allSitePage.nodes.find(
-    page => page.path === location.pathname
+    page =>
+      withoutTrailingSlash(page.path) ===
+      withoutTrailingSlash(location.pathname)
   )
 
   if (!currentSitePage || !currentSitePage.context.breadcrumbs) {

--- a/src/components/heading/heading.css
+++ b/src/components/heading/heading.css
@@ -1,4 +1,5 @@
 .heading {
+  display: inline-block; /* Added to make sure nothing changes visually when converting heading to a span to break 1.3.1 */
   font-family: Arial, sans-serif;
   font-weight: 700;
   margin: 0 0 1em; /* Using em instead of rem to adjust based on heading font size */

--- a/src/components/heading/heading.js
+++ b/src/components/heading/heading.js
@@ -1,6 +1,9 @@
-import React from "react"
+import React, { useContext } from "react"
 import classNames from "classnames"
 import * as PropTypes from "prop-types"
+
+import CONSTANTS from "../../data/rules/constants"
+import AccessibilityRulesContext from "../accessibility-rules/accessibility-rules-context"
 
 import "./heading.css"
 
@@ -20,7 +23,10 @@ const Heading = ({
   headingStyle,
   ...rest
 }) => {
-  const HeadingWithLevel = `h${headingLevel}`
+  const { rules } = useContext(AccessibilityRulesContext)
+  const HeadingWithLevel = rules[CONSTANTS.HEADER_HAS_ROLE_HEADER]
+    ? `h${headingLevel}`
+    : "span"
   return (
     <HeadingWithLevel
       className={classNames("heading", {

--- a/src/components/link/inaccessible-link.js
+++ b/src/components/link/inaccessible-link.js
@@ -1,0 +1,18 @@
+import React from "react"
+import * as PropTypes from "prop-types"
+
+const InaccessibleLink = ({ children, url, ...rest }) => (
+  <span {...rest} onClick={() => (location.href = url)}>
+    {children}
+  </span>
+)
+
+InaccessibleLink.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+  url: PropTypes.string,
+}
+
+export default InaccessibleLink

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -1,15 +1,32 @@
-import React from "react"
+import React, { useContext } from "react"
 import * as PropTypes from "prop-types"
 import classNames from "classnames"
+import AccessibilityRulesContext from "../accessibility-rules/accessibility-rules-context"
+import InaccessibleLink from "./inaccessible-link"
 
 import "./link.css"
+import CONSTANTS from "../../data/rules/constants"
 
-const Link = ({ children, className, title, url }) => (
-  <a href={url} className={classNames("link", { [className]: className })}>
-    {title}
-    {children}
-  </a>
-)
+const Link = ({ children, className, title, url }) => {
+  const { rules } = useContext(AccessibilityRulesContext)
+  if (!rules[CONSTANTS.LINK_HAS_ROLE_LINK]) {
+    return (
+      <InaccessibleLink
+        url={url}
+        className={classNames("link", { [className]: className })}
+      >
+        {title}
+        {children}
+      </InaccessibleLink>
+    )
+  }
+  return (
+    <a href={url} className={classNames("link", { [className]: className })}>
+      {title}
+      {children}
+    </a>
+  )
+}
 
 Link.propTypes = {
   children: PropTypes.node,

--- a/src/components/navigation-list/navigation-list.js
+++ b/src/components/navigation-list/navigation-list.js
@@ -1,10 +1,12 @@
-import React from "react"
+import React, { useContext } from "react"
 import classNames from "classnames"
 import * as PropTypes from "prop-types"
 
+import CONSTANTS from "../../data/rules/constants"
+import { toSlug } from "../../util/url-util"
+import AccessibilityRulesContext from "../accessibility-rules/accessibility-rules-context"
 import Link from "../link"
 import Heading from "../semantic-heading"
-import { toSlug } from "../../util/url-util"
 
 import "./navigation-list.css"
 
@@ -13,37 +15,43 @@ const NavigationList = ({
   hideHeading,
   isHorizontal = false,
   links,
-}) => (
-  <div>
-    {heading && (
-      <Heading
-        id={`navigation-${toSlug(heading)}-heading`}
-        className={classNames({
-          "visually-hidden": hideHeading,
-        })}
+}) => {
+  const { rules } = useContext(AccessibilityRulesContext)
+  const NavElement = rules[CONSTANTS.GROUP_RELATED_LINKS_USING_THE_NAV_ELEMENT]
+    ? "nav"
+    : "div"
+  return (
+    <div>
+      {heading && (
+        <Heading
+          id={`navigation-${toSlug(heading)}-heading`}
+          className={classNames({
+            "visually-hidden": hideHeading,
+          })}
+        >
+          {heading}
+        </Heading>
+      )}
+      <NavElement
+        aria-labelledby={
+          heading ? `navigation-${toSlug(heading)}-heading` : undefined
+        }
       >
-        {heading}
-      </Heading>
-    )}
-    <nav
-      aria-labelledby={
-        heading ? `navigation-${toSlug(heading)}-heading` : undefined
-      }
-    >
-      <ul
-        className={classNames("navigation-list", {
-          "navigation-list--horizontal": isHorizontal,
-        })}
-      >
-        {links.map(link => (
-          <li className="navigation-list__item" key={toSlug(link.title)}>
-            <Link title={link.title} url={link.url} />
-          </li>
-        ))}
-      </ul>
-    </nav>
-  </div>
-)
+        <ul
+          className={classNames("navigation-list", {
+            "navigation-list--horizontal": isHorizontal,
+          })}
+        >
+          {links.map(link => (
+            <li className="navigation-list__item" key={toSlug(link.title)}>
+              <Link title={link.title} url={link.url} />
+            </li>
+          ))}
+        </ul>
+      </NavElement>
+    </div>
+  )
+}
 
 NavigationList.propTypes = {
   heading: PropTypes.string,

--- a/src/components/semantic-region/article.js
+++ b/src/components/semantic-region/article.js
@@ -1,14 +1,22 @@
 import React, { useContext } from "react"
 import * as PropTypes from "prop-types"
+import CONSTANTS from "../../data/rules/constants"
+import AccessibilityRulesContext from "../accessibility-rules/accessibility-rules-context"
 import HeadingLevelContext from "../semantic-heading/heading-level-context"
 
 const Article = ({ children, setRef, ...rest }) => {
   const headingLevel = useContext(HeadingLevelContext)
+  const { rules } = useContext(AccessibilityRulesContext)
+  const ArticleElement = rules[
+    CONSTANTS.USE_ARIA_LANDMARKS_TO_IDENTIFY_REGIONS_OF_A_PAGE
+  ]
+    ? "article"
+    : "div"
   return (
     <HeadingLevelContext.Provider value={headingLevel + 1}>
-      <article {...rest} ref={setRef}>
+      <ArticleElement {...rest} ref={setRef}>
         {children}
-      </article>
+      </ArticleElement>
     </HeadingLevelContext.Provider>
   )
 }

--- a/src/components/semantic-region/main.js
+++ b/src/components/semantic-region/main.js
@@ -1,13 +1,21 @@
 import React, { useContext } from "react"
 import * as PropTypes from "prop-types"
 
+import CONSTANTS from "../../data/rules/constants"
+import AccessibilityRulesContext from "../accessibility-rules/accessibility-rules-context"
 import HeadingLevelContext from "../semantic-heading/heading-level-context"
 
 const Main = props => {
   const headingLevel = useContext(HeadingLevelContext)
+  const { rules } = useContext(AccessibilityRulesContext)
+  const MainElement = rules[
+    CONSTANTS.USE_ARIA_LANDMARKS_TO_IDENTIFY_REGIONS_OF_A_PAGE
+  ]
+    ? "main"
+    : "div"
   return (
     <HeadingLevelContext.Provider value={headingLevel + 1}>
-      <main {...props}>{props.children}</main>
+      <MainElement {...props}>{props.children}</MainElement>
     </HeadingLevelContext.Provider>
   )
 }

--- a/src/components/semantic-region/section.js
+++ b/src/components/semantic-region/section.js
@@ -1,13 +1,21 @@
 import React, { useContext } from "react"
 import * as PropTypes from "prop-types"
 
+import CONSTANTS from "../../data/rules/constants"
+import AccessibilityRulesContext from "../accessibility-rules/accessibility-rules-context"
 import HeadingLevelContext from "../semantic-heading/heading-level-context"
 
 const Section = props => {
   const headingLevel = useContext(HeadingLevelContext)
+  const { rules } = useContext(AccessibilityRulesContext)
+  const SectionElement = rules[
+    CONSTANTS.USE_ARIA_LANDMARKS_TO_IDENTIFY_REGIONS_OF_A_PAGE
+  ]
+    ? "section"
+    : "div"
   return (
     <HeadingLevelContext.Provider value={headingLevel + 1}>
-      <section {...props}>{props.children}</section>
+      <SectionElement {...props}>{props.children}</SectionElement>
     </HeadingLevelContext.Provider>
   )
 }

--- a/src/data/rules/constants.js
+++ b/src/data/rules/constants.js
@@ -1,5 +1,7 @@
 const CONSTANTS = {
   IMAGE_ALT: "1.1.1-images-must-have-alternate-text",
+  GROUP_RELATED_LINKS_USING_THE_NAV_ELEMENT:
+    "1.3.1-group-related-links-using-the-nav-element",
   HEADER_HAS_ROLE_HEADER: "1.3.1-header-has-role-header",
   LINK_HAS_ROLE_LINK: "1.3.1-link-has-role-link",
   COLOR_CONTRAST: "1.4.3-elements-must-have-sufficient-color-contrast",

--- a/src/data/rules/constants.js
+++ b/src/data/rules/constants.js
@@ -1,5 +1,6 @@
 const CONSTANTS = {
   IMAGE_ALT: "1.1.1-images-must-have-alternate-text",
+  LINK_HAS_ROLE_LINK: "1.3.1-link-has-role-link",
   COLOR_CONTRAST: "1.4.3-elements-must-have-sufficient-color-contrast",
   BYPASS: "2.4.1-page-must-have-means-to-bypass-repeated-blocks",
   HTML_HAS_LANG: "3.1.1-html-element-must-have-a-lang-attribute",

--- a/src/data/rules/constants.js
+++ b/src/data/rules/constants.js
@@ -1,5 +1,6 @@
 const CONSTANTS = {
   IMAGE_ALT: "1.1.1-images-must-have-alternate-text",
+  HEADER_HAS_ROLE_HEADER: "1.3.1-header-has-role-header",
   LINK_HAS_ROLE_LINK: "1.3.1-link-has-role-link",
   COLOR_CONTRAST: "1.4.3-elements-must-have-sufficient-color-contrast",
   BYPASS: "2.4.1-page-must-have-means-to-bypass-repeated-blocks",

--- a/src/data/rules/constants.js
+++ b/src/data/rules/constants.js
@@ -4,6 +4,8 @@ const CONSTANTS = {
     "1.3.1-group-related-links-using-the-nav-element",
   HEADER_HAS_ROLE_HEADER: "1.3.1-header-has-role-header",
   LINK_HAS_ROLE_LINK: "1.3.1-link-has-role-link",
+  USE_ARIA_LANDMARKS_TO_IDENTIFY_REGIONS_OF_A_PAGE:
+    "1.3.1-use-aria-landmarks-to-identify-regions-of-a-page",
   COLOR_CONTRAST: "1.4.3-elements-must-have-sufficient-color-contrast",
   BYPASS: "2.4.1-page-must-have-means-to-bypass-repeated-blocks",
   HTML_HAS_LANG: "3.1.1-html-element-must-have-a-lang-attribute",

--- a/src/data/rules/group-related-links-using-the-nav-element.js
+++ b/src/data/rules/group-related-links-using-the-nav-element.js
@@ -1,0 +1,8 @@
+const groupRelatedLinksUsingTheNavElement = {
+  title: "Group related links using the 'nav' element",
+  description:
+    "Ensures assistive technology can properly locate and skip past navigation elements.",
+  wcagId: "1.3.1",
+}
+
+export default groupRelatedLinksUsingTheNavElement

--- a/src/data/rules/header-has-role-header.js
+++ b/src/data/rules/header-has-role-header.js
@@ -1,0 +1,8 @@
+const headerHasRoleHeader = {
+  title: "Header has role 'header'",
+  description:
+    "Ensures headers are recognized as such by assistive technology and provides structure.",
+  wcagId: "1.3.1",
+}
+
+export default headerHasRoleHeader

--- a/src/data/rules/index.js
+++ b/src/data/rules/index.js
@@ -7,6 +7,7 @@ import linkHasRoleLink from "./link-has-role-link"
 import groupRelatedLinksUsingTheNavElement from "./group-related-links-using-the-nav-element"
 import headerHasRoleHeader from "./header-has-role-header"
 import label from "./label"
+import useARIALandmarksToIdentifyRegionsOfAPage from "./use-semantic-regions"
 
 const rules = [
   bypass,
@@ -18,6 +19,7 @@ const rules = [
   linkHasRoleLink,
   imageAlt,
   label,
+  useARIALandmarksToIdentifyRegionsOfAPage,
 ]
 
 export default rules

--- a/src/data/rules/index.js
+++ b/src/data/rules/index.js
@@ -3,6 +3,7 @@ import colorContrast from "./color-contrast"
 import htmlHasLang from "./html-has-lang"
 import htmlLangValid from "./html-lang-valid"
 import imageAlt from "./image-alt"
+import linkHasRoleLink from "./link-has-role-link"
 import label from "./label"
 
 const rules = [
@@ -10,6 +11,7 @@ const rules = [
   colorContrast,
   htmlHasLang,
   htmlLangValid,
+  linkHasRoleLink,
   imageAlt,
   label,
 ]

--- a/src/data/rules/index.js
+++ b/src/data/rules/index.js
@@ -4,12 +4,14 @@ import htmlHasLang from "./html-has-lang"
 import htmlLangValid from "./html-lang-valid"
 import imageAlt from "./image-alt"
 import linkHasRoleLink from "./link-has-role-link"
+import groupRelatedLinksUsingTheNavElement from "./group-related-links-using-the-nav-element"
 import headerHasRoleHeader from "./header-has-role-header"
 import label from "./label"
 
 const rules = [
   bypass,
   colorContrast,
+  groupRelatedLinksUsingTheNavElement,
   htmlHasLang,
   htmlLangValid,
   headerHasRoleHeader,

--- a/src/data/rules/index.js
+++ b/src/data/rules/index.js
@@ -4,6 +4,7 @@ import htmlHasLang from "./html-has-lang"
 import htmlLangValid from "./html-lang-valid"
 import imageAlt from "./image-alt"
 import linkHasRoleLink from "./link-has-role-link"
+import headerHasRoleHeader from "./header-has-role-header"
 import label from "./label"
 
 const rules = [
@@ -11,6 +12,7 @@ const rules = [
   colorContrast,
   htmlHasLang,
   htmlLangValid,
+  headerHasRoleHeader,
   linkHasRoleLink,
   imageAlt,
   label,

--- a/src/data/rules/link-has-role-link.js
+++ b/src/data/rules/link-has-role-link.js
@@ -1,0 +1,8 @@
+const linkHasRoleLink = {
+  title: "Link has role 'link'",
+  description:
+    "Ensures links are correctly presented to assistive technology and are made available in lists of links on the page.",
+  wcagId: "1.3.1",
+}
+
+export default linkHasRoleLink

--- a/src/data/rules/use-semantic-regions.js
+++ b/src/data/rules/use-semantic-regions.js
@@ -1,0 +1,7 @@
+const useARIALandmarksToIdentifyRegionsOfAPage = {
+  title: "Use ARIA landmarks to identify regions of a page",
+  description: "",
+  wcagId: "1.3.1",
+}
+
+export default useARIALandmarksToIdentifyRegionsOfAPage

--- a/src/util/url-util.js
+++ b/src/util/url-util.js
@@ -18,3 +18,5 @@ export const createProductUrl = (language, gender, type, product) => {
   }
   return url
 }
+
+export const withoutTrailingSlash = url => url.replace(/\/$/, "")


### PR DESCRIPTION
Adding four rules connected to 1.3.1 Info and relationships

These, when disabled, will remove semantics from headings, links (also breaking keyboard navigation, which I don't know if it should implicitly break?), landmarks and navigation groups (nav-elements).

Also fixed a bug that made breadcrumbs fail to load when reloading a page.