### PR TITLE
Remove aria-haspopup for dropdown component

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -7,7 +7,7 @@ import Button from "../button"
 
 import "./dropdown.css"
 
-const DropDown = ({ buttonText, ButtonType = Button, children, className }) => {
+const DropDown = ({ buttonText, children, className }) => {
   const { isOpen, closeOnEscapeKey, toggleIsOpen } = useModal()
   const toggleButtonRef = useRef(null)
   return (
@@ -16,15 +16,14 @@ const DropDown = ({ buttonText, ButtonType = Button, children, className }) => {
         [className]: className,
       })}
     >
-      <ButtonType
-        aria-haspopup="true"
+      <Button
         className="dropdown-toggle"
         aria-expanded={isOpen}
         onClick={() => toggleIsOpen()}
         setRef={toggleButtonRef}
       >
         {buttonText}
-      </ButtonType>
+      </Button>
       <div
         className="dropdown__container"
         hidden={!isOpen}
@@ -38,7 +37,6 @@ const DropDown = ({ buttonText, ButtonType = Button, children, className }) => {
 
 DropDown.propTypes = {
   buttonText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  ButtonType: PropTypes.element,
   children: PropTypes.node,
   className: PropTypes.string,
 }


### PR DESCRIPTION
Aria-haspopup declares that the dropdown is a menu component, and that it is possible to navigate with the arrow keys.
I considered using aria-haspopup with said arrow key-navigation, but believe users might not expect that behaviour.
Therefore, I am going with just removing aria-haspopup, to have it announced as a summary and details-component instead.

Ref. #21 