### PR TITLE
Bugfix - skip to content link has to respect page language as well, 

### DIFF
--- a/src/components/skip-link/skip-link.js
+++ b/src/components/skip-link/skip-link.js
@@ -1,19 +1,22 @@
 import React, { useContext } from "react"
 import * as PropTypes from "prop-types"
 
+import TEXTS from "../../data/texts"
+import { useLanguage } from "../language"
 import CONSTANTS from "../../data/rules/constants"
 import AccessibilityRules from "../accessibility-rules"
 
 import "./skip-link.css"
 
 const SkipLink = ({ mainTagId = "main" }) => {
+  const { language } = useLanguage()
   const { rules } = useContext(AccessibilityRules.context)
   if (rules[CONSTANTS.BYPASS] === false) {
     return null
   }
   return (
     <a href={`#${mainTagId}`} className="skip-link">
-      Skip to main content
+      {TEXTS[language].SKIP_TO_CONTENT}
     </a>
   )
 }

--- a/src/data/texts/texts.en.js
+++ b/src/data/texts/texts.en.js
@@ -1,6 +1,7 @@
 const textsEN = {
   // general
   LANG: "English",
+  SKIP_TO_CONTENT: "Skip to content",
   CURRENCY: "USD",
   MENU: "Menu",
   RETAIL_PRICE: price => `Previous price: ${price}`,

--- a/src/data/texts/texts.no.js
+++ b/src/data/texts/texts.no.js
@@ -1,6 +1,7 @@
 const textsNO = {
   // general
   LANG: "norsk",
+  SKIP_TO_CONTENT: "Hopp til innhold",
   CURRENCY: "NOK",
   MENU: "Meny",
   RETAIL_PRICE: price => `Førpris: ${price}`,


### PR DESCRIPTION
otherwise we fail WCAG 3.1.2 Language of Parts (AA).

Simple fix implementation (dictionary item for Norwegian added).

Wording could be improved (Skip to main content) but I think it's understandable...