### PR TITLE
Ambiguous / duplicate IDs are not allowed,

### DIFF
--- a/src/components/accessibility-configurator/accessibility-configurator.js
+++ b/src/components/accessibility-configurator/accessibility-configurator.js
@@ -1,4 +1,5 @@
 import React, { Fragment, useContext } from "react"
+import * as PropTypes from "prop-types"
 import RuleSection from "../rule/rule-section"
 import { graphql, useStaticQuery } from "gatsby"
 import AccessibilityRules from "../accessibility-rules"
@@ -7,7 +8,7 @@ import ToggleSwitch from "../toggle-switch"
 const getRules = data => data.allInternalRule.nodes
 const getSuccessCriteria = data => data.allWcagSuccessCriteria.nodes
 
-const GlobalRulesToggle = () => {
+const GlobalRulesToggle = ({ variant }) => {
   const { rules, setAllRules } = useContext(AccessibilityRules.context)
   const firstRule = Object.keys(rules)[0]
   const initialValue = rules[firstRule]
@@ -16,7 +17,7 @@ const GlobalRulesToggle = () => {
       <ToggleSwitch
         checked={initialValue}
         helpText="Override all individually set rules"
-        id="all-rules"
+        id={`all-rules__${variant}`}
         label="Toggle all rules"
         onClick={() => setAllRules(!initialValue)}
       />
@@ -24,7 +25,11 @@ const GlobalRulesToggle = () => {
   )
 }
 
-const AccessibilityConfigurator = () => {
+GlobalRulesToggle.propTypes = {
+  variant: PropTypes.string.isRequired,
+}
+
+const AccessibilityConfigurator = ({ variant }) => {
   const ruleData = useStaticQuery(graphql`
     {
       allWcagSuccessCriteria {
@@ -49,7 +54,7 @@ const AccessibilityConfigurator = () => {
   const rules = getRules(ruleData)
   return (
     <Fragment>
-      <GlobalRulesToggle />
+      <GlobalRulesToggle variant={variant} />
       {getSuccessCriteria(ruleData)
         .filter(successCriterion =>
           rules.find(rule => rule.wcagId === successCriterion["ref_id"])
@@ -65,10 +70,15 @@ const AccessibilityConfigurator = () => {
               successCriterion.level
             })`}
             url={successCriterion.url}
+            variant={variant}
           />
         ))}
     </Fragment>
   )
+}
+
+AccessibilityConfigurator.propTypes = {
+  variant: PropTypes.string.isRequired,
 }
 
 export default AccessibilityConfigurator

--- a/src/components/accessibility-configurator/accessibility-slide-in.js
+++ b/src/components/accessibility-configurator/accessibility-slide-in.js
@@ -1,17 +1,22 @@
 import React from "react"
+import * as PropTypes from "prop-types"
 
 import TEXTS from "../../data/texts"
 import { useLanguage } from "../language"
 import SlideIn from "../slide-in"
 import AccessibilityConfigurator from "./accessibility-configurator"
 
-const AccessibilitySlideIn = () => {
+const AccessibilitySlideIn = ({ variant }) => {
   const { language } = useLanguage()
   return (
     <SlideIn toggleText={TEXTS[language].RULE_SET}>
-      <AccessibilityConfigurator />
+      <AccessibilityConfigurator variant={variant} />
     </SlideIn>
   )
+}
+
+AccessibilitySlideIn.propTypes = {
+  variant: PropTypes.string.isRequired,
 }
 
 export default AccessibilitySlideIn

--- a/src/components/header/header-menu-desktop.js
+++ b/src/components/header/header-menu-desktop.js
@@ -10,7 +10,7 @@ const HeaderMenuDesktop = () => (
     <ContentMenu />
     <div className="header__menus">
       <LanguageSelector />
-      <AccessibilitySlideIn />
+      <AccessibilitySlideIn variant="desktop" />
     </div>
   </>
 )

--- a/src/components/header/header-menu-mobile.js
+++ b/src/components/header/header-menu-mobile.js
@@ -15,7 +15,7 @@ const HeaderMenuMobile = () => {
       <ContentMenu />
       <div className="header__menus">
         <LanguageSelector />
-        <AccessibilitySlideIn />
+        <AccessibilitySlideIn variant="mobile" />
       </div>
     </SlideIn>
   )

--- a/src/components/rule/rule-list.js
+++ b/src/components/rule/rule-list.js
@@ -5,13 +5,13 @@ import RuleSelector from "./rule-selector"
 import { Section } from "../semantic-region"
 import Heading from "../semantic-heading"
 
-const RuleList = ({ rules }) => {
+const RuleList = ({ rules, variant }) => {
   if (rules.length > 0) {
     return (
       <Section>
         <Heading>Rules</Heading>
         {rules.map(rule => (
-          <RuleSelector key={rule.key} rule={rule} />
+          <RuleSelector key={rule.key} rule={rule} variant={variant} />
         ))}
       </Section>
     )
@@ -23,6 +23,7 @@ const RuleList = ({ rules }) => {
 RuleList.propTypes = {
   headingLevel: PropTypes.number,
   rules: PropTypes.arrayOf(RuleSelector.propTypes.rule),
+  variant: PropTypes.string.isRequired,
 }
 
 export default RuleList

--- a/src/components/rule/rule-section.js
+++ b/src/components/rule/rule-section.js
@@ -7,7 +7,7 @@ import RuleList from "./rule-list"
 
 import "./rule-section.css"
 
-const RuleSection = ({ description, rules, title, url }) => {
+const RuleSection = ({ description, rules, title, url, variant }) => {
   return (
     <Article className="rule__section">
       <Heading>
@@ -16,7 +16,7 @@ const RuleSection = ({ description, rules, title, url }) => {
         </a>
       </Heading>
       {description && <p>{description}</p>}
-      {rules && <RuleList rules={rules} />}
+      {rules && <RuleList rules={rules} variant={variant} />}
     </Article>
   )
 }
@@ -27,6 +27,7 @@ RuleSection.propTypes = {
   rules: RuleList.propTypes.rules,
   title: PropTypes.string,
   url: PropTypes.string,
+  variant: PropTypes.string.isRequired,
 }
 
 export default RuleSection

--- a/src/components/rule/rule-selector.js
+++ b/src/components/rule/rule-selector.js
@@ -3,14 +3,14 @@ import AccessibilityRules from "../accessibility-rules"
 import ToggleSwitch from "../toggle-switch"
 import * as PropTypes from "prop-types"
 
-const RuleSelector = ({ rule }) => {
+const RuleSelector = ({ rule, variant }) => {
   const { rules, setRule } = useContext(AccessibilityRules.context)
   const currentValue = rules[rule.key] || false
   return (
     <ToggleSwitch
       checked={currentValue}
       helpText={rule.description}
-      id={rule.key}
+      id={`${rule.key}__${variant}`}
       key={rule.key}
       label={rule.title}
       onClick={() => setRule(rule.key, !currentValue)}
@@ -24,6 +24,7 @@ RuleSelector.propTypes = {
     description: PropTypes.string,
     title: PropTypes.string,
   }),
+  variant: PropTypes.string.isRequired,
 }
 
 export default RuleSelector


### PR DESCRIPTION
even inside hidden HTML parents and fail WCAG SC 4.1.1 Parsing (A).
 
Maybe a bit strict interpretation as it seems not to influence user experience but it does trigger multiple automatic testing tools based on ACT-rules.

I've used props, was also considering context...